### PR TITLE
Fix: async used in a client component

### DIFF
--- a/src/components/posts/post-create-form.tsx
+++ b/src/components/posts/post-create-form.tsx
@@ -9,7 +9,7 @@ interface PostCreateFormProps {
     slug: string;
 }
 
-export default async function PostCreateForm({ slug }: PostCreateFormProps) {
+export default function PostCreateForm({ slug }: PostCreateFormProps) {
 
     const [formState, action] = useFormState(
         actions.createPost.bind(null, slug),


### PR DESCRIPTION
Client components in Next.js cannot be declared as top-level async functions. 

 working locally.